### PR TITLE
Sum Fix

### DIFF
--- a/html/user.php
+++ b/html/user.php
@@ -60,7 +60,7 @@
 			</div>
 
 				$<input type="text" id="thingy" style="width:50px;" name="dollar_amount">
-				for 
+				each for 
 				<input type="text" name="reason" id="charge_reason">
 
 			<?php
@@ -149,7 +149,7 @@
                             $next_row = $rows[$i+1];
                             if ($next_row['id'] == $row['id'])
                             {
-                            	if ($row['toId']==$current_id)
+                            	if ($row['owner']==$current_id)
                             	{
 	                            	$running_value = $running_value+$row['amount'];
 	                            }
@@ -208,7 +208,7 @@
                         {
                         	$total_amounts[$row['id']]=$running_value;
                         	$running_names = $running_names.$name_row[$row['fromId']];
-                        	if ($row['toId']==$current_id)
+                        	if ($row['owner']==$current_id)
                         	{
 		                        $total_from_others[$row['fromId']] = $total_from_others[$row['fromId']] + $row['amount'];
                         	}
@@ -221,7 +221,7 @@
     					{
                         	$total_amounts[$row['id']]=$running_value*-1;
                         	$running_names = $running_names.$name_row[$row['toId']];
-                        	if ($row['toId']==$current_id)
+                        	if ($row['owner']==$current_id)
                         	{
 		                       	$total_from_others[$row['toId']] = $total_from_others[$row['toId']] + $row['amount'];
 		                    }
@@ -246,7 +246,7 @@
 							if ($result2->num_rows > 0) {
 								$row2 = $result2->fetch_assoc();
 							}
-                        	if ($row['toId']==$current_id)
+                        	if ($row['owner']==$current_id)
 							{
     							echo "payment";
     						}
@@ -268,7 +268,7 @@
 							if ($result2->num_rows > 0) {
 								$row2 = $result2->fetch_assoc();
 							}
-                        	if ($row['toId']==$current_id)
+                        	if ($row['owner']==$current_id)
 							{
 	    						echo "payment";
 	    					}

--- a/tools/create_backup.sh
+++ b/tools/create_backup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "Creates a backup of the database. Requires password of mysql user caps"
+mysqldump -u caps -p --all-databases > "logs/backup_`date +%m_%d_%y`.sql"


### PR DESCRIPTION
Unexpected behavior seen a month ago turned out to be due to repeat transactions, not summing logic. This PR reverts the summing logic fix by @greyl and adds in a database backup script (requires password of mysql user). A small fix in text more explicitly shows that charge transactions do not auto-split.

Since the unexpected behavior still exists I have opened issue #2 to track it.